### PR TITLE
add support of projections

### DIFF
--- a/lib/Catmandu/Store/MongoDB.pm
+++ b/lib/Catmandu/Store/MongoDB.pm
@@ -46,11 +46,13 @@ our $VERSION = '0.0303';
     my $hits = $store->bag->search(query => '{"name":"Patrick"}');
     my $hits = $store->bag->search(query => '{"name":"Patrick"}' , sort => { age => -1} );
     my $hits = $store->bag->search(query => {name => "Patrick"} , start => 0 , limit => 100);
+    my $hits = $store->bag->search(query => {name => "Patrick"} , fields => {_id => 0, name => 1});
     
     my $next_page = $hits->next_page;
     my $hits = $store->bag->search(query => '{"name":"Patrick"}' , page => $next_page);
 
     my $iterator = $store->bag->searcher(query => {name => "Patrick"});
+    my $iterator = $store->bag->searcher(query => {name => "Patrick"}, fields => {_id => 0, name => 1});
 
 
 
@@ -83,6 +85,12 @@ Return the MongoDB::MongoClient instance.
 =head2 database
 
 Return a MongoDB::Database instance.
+
+=head1 Search
+
+Search the database: see L<Catmandu::Searchable>. This module supports an additional search parameter:
+
+    - fields => { <field> => <0|1> } : limit fields to return from a query
 
 =cut
 

--- a/lib/Catmandu/Store/MongoDB/Bag.pm
+++ b/lib/Catmandu/Store/MongoDB/Bag.pm
@@ -154,16 +154,21 @@ sub delete_by_query {
 sub search {
     my ($self, %args) = @_;
 
-    my $query = $args{query};
-    my $start = $args{start};
-    my $limit = $args{limit};
-    my $bag   = $args{reify};
-
+    my $query  = $args{query};
+    my $start  = $args{start};
+    my $limit  = $args{limit};
+    my $bag    = $args{reify}; # when is this arg set?
+    my $fields = $args{fields};
+    
     my $cursor = $self->collection->find($query)->skip($start)->limit($limit);
     if ($bag) { # only retrieve _id
         $cursor->fields({})
     }
-    if (my $sort =  $args{sort}) {
+    elsif ($fields) { # only retrieve specified fields
+        $cursor->fields($fields);
+    }
+
+    if (my $sort = $args{sort}) {
         $cursor->sort($sort);
     }
 

--- a/lib/Catmandu/Store/MongoDB/Searcher.pm
+++ b/lib/Catmandu/Store/MongoDB/Searcher.pm
@@ -7,18 +7,20 @@ use Moo;
 
 with 'Catmandu::Iterable';
 
-has bag   => (is => 'ro', required => 1);
-has query => (is => 'ro', required => 1);
-has start => (is => 'ro', required => 1);
-has limit => (is => 'ro', required => 1);
-has total => (is => 'ro');
-has sort  => (is => 'ro');
+has bag    => (is => 'ro', required => 1);
+has query  => (is => 'ro', required => 1);
+has start  => (is => 'ro', required => 1);
+has limit  => (is => 'ro', required => 1);
+has total  => (is => 'ro');
+has sort   => (is => 'ro');
+has fields => (is => 'ro');
 
 sub generator {
     my ($self) = @_;
     sub {
         state $cursor = do {
             my $c = $self->bag->collection->find($self->query);
+            $c->fields($self->fields) if defined $self->fields;
             # limit is unused because the perl driver doesn't expose batchSize
             $c->limit($self->total) if defined $self->total;
             $c->sort($self->sort) if defined $self->sort;
@@ -33,13 +35,15 @@ sub slice { # TODO constrain total?
     my ($self, $start, $total) = @_;
     $start //= 0;
     $self->new(
-        bag   => $self->bag,
-        query => $self->query,
-        start => $self->start + $start,
-        limit => $self->limit,
-        total => $total,
-        sort  => $self->sort,
+        bag    => $self->bag,
+        query  => $self->query,
+        start  => $self->start + $start,
+        limit  => $self->limit,
+        total  => $total,
+        sort   => $self->sort,
+        fields => $self->fields,
     );
+
 }
 
 

--- a/t/01-store.t
+++ b/t/01-store.t
@@ -10,7 +10,7 @@ use Catmandu::Store::MongoDB;
 
 use MongoDBTest '$conn';
 
-plan tests => 10;
+plan tests => 12;
 
 ok $conn;
 
@@ -45,6 +45,12 @@ is $store->bag->count , 1;
 $store->bag->delete_all;
 
 is $store->bag->count , 0;
+
+my $obj3 = $store->bag->add({ _id => '789' , char => 'ABC', num => '123' });
+
+is_deeply $store->bag->searcher(query => {char => "ABC"}, fields => { num => 1, _id => 0 })->first, { num => '123'};
+
+is_deeply $store->bag->search(query => {char => "ABC"}, fields => { _id => 1 })->first, { _id => '789'};
 
 END {
 	if ($db) {


### PR DESCRIPTION
Add support of [projections](http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/), so you can limit fields to return from a query.

Optional parameter "fields" added to search() and searcher().

Question: When is the argument "$args{reify}" set in "lib/Catmandu/Store/MongoDB/Bag.pm"?