### PR TITLE
 Prepare for 1.0.0 MongoDB driver

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,10 +3,11 @@ requires 'perl', 'v5.10.1';
 on 'test', sub {
   requires 'Test::Exception', '0.32';
   requires 'Test::More', '1.001003';
+  requires 'Test::Warn', 0;
   requires 'Test::Pod', 0;
   requires 'Software::License','0.103010';
 };
 
 requires 'Catmandu', '0.9205';
-requires 'MongoDB', 'v0.705.0.0';
+requires 'MongoDB', '1.0.0';
 requires 'Moo','1.006000';

--- a/lib/Catmandu/Store/MongoDB.pm
+++ b/lib/Catmandu/Store/MongoDB.pm
@@ -15,6 +15,12 @@ Catmandu::Store::MongoDB - A searchable store backed by MongoDB
 
 =head1 SYNOPSIS
 
+    # On the command line
+    $ catmandu import -v JSON --multiline 1 to MongoDB --database_name bibliography --bag books < books.json
+    $ catmandu export MongoDB --database_name bibliography --bag books to YAML
+    $ catmandu count MongoDB --database_name bibliography --bag books --query '{"PublicationYear": "1937"}'
+
+    # In perl
     use Catmandu::Store::MongoDB;
 
     my $store = Catmandu::Store::MongoDB->new(database_name => 'test');
@@ -46,37 +52,38 @@ Catmandu::Store::MongoDB - A searchable store backed by MongoDB
 
     my $iterator = $store->bag->searcher(query => {name => "Patrick"});
 
-
-
 =head1 DESCRIPTION
 
 A Catmandu::Store::MongoDB is a Perl package that can store data into
-MongoDB databases. The database as a whole is called a 'store'.
+L<MongoDB> databases. The database as a whole is called a 'store'.
 Databases also have compartments (e.g. tables) called Catmandu::Bag-s.
+
+=head1 DEPRECATION NOTICE
+
+The following connection parameters are depreacted and will be removed in a future version of this module:
+    
+    - connect_retry
+    - connect_retry_sleep
 
 =head1 METHODS
 
 =head2 new(database_name => $name , %opts )
 
-Create a new Catmandu::Store::MongoDB store with name $name. Optionally provide
-connection parameters (see MongoDB::MongoClient for possible options).
-
-This module support to additional connection parameters:
-    
-    - connect_retry => NUM : connection's should be retried NUM times for success
-    - connect_retry_sleep => NUM : sleep NUM seconds after any connection failure
+Create a new Catmandu::Store::MongoDB store with name $name. Optionally 
+provide connection parameters (see L<MongoDB::MongoClient> for possible 
+options).
 
 =head2 bag($name)
 
-Create or retieve a bag with name $name. Returns a Catmandu::Bag.
+Create or retieve a bag with name $name. Returns a L<Catmandu::Bag>.
 
 =head2 client
 
-Return the MongoDB::MongoClient instance.
+Return the L<MongoDB::MongoClient> instance.
 
 =head2 database
 
-Return a MongoDB::Database instance.
+Return a L<MongoDB::Database> instance.
 
 =cut
 
@@ -148,6 +155,10 @@ L<Catmandu::Bag>, L<Catmandu::Searchable> , L<MongoDB::MongoClient>
 =head1 AUTHOR
 
 Nicolas Steenlant, C<< <nicolas.steenlant at ugent.be> >>
+
+=head1 CONTRIBUTORS
+
+Johann Rôlschewski, C<< <jorol at cpan.org> >>
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/Catmandu/Store/MongoDB.pm
+++ b/lib/Catmandu/Store/MongoDB.pm
@@ -87,24 +87,22 @@ Return a L<MongoDB::Database> instance.
 
 =cut
 
-my $CLIENT_ARGS = [qw(
-    host
-    w
-    wtimeout
-    j
-    auto_reconnect
-    auto_connect
-    timeout
-    username
-    password
-    db_name
-    query_timeout
-    max_bson_size
-    find_master
-    ssl
-    dt_type
-    inflate_dbrefs
-)];
+my $CLIENT_ARGS = [
+    qw(
+        connect_timeout_ms
+        db_name
+        dt_type
+        find_master
+        host
+        j
+        password
+        socket_timeout_ms
+        ssl
+        username
+        w
+        wtimeout
+        )
+];
 
 has connect_retry        => (is => 'ro', default => sub { 0 } );
 has connect_retry_sleep  => (is => 'ro', default => sub { 1 } );

--- a/lib/Catmandu/Store/MongoDB.pm
+++ b/lib/Catmandu/Store/MongoDB.pm
@@ -7,17 +7,11 @@ use MongoDB;
 
 with 'Catmandu::Store';
 
+our $VERSION = '0.0303';
+
 =head1 NAME
 
 Catmandu::Store::MongoDB - A searchable store backed by MongoDB
-
-=head1 VERSION
-
-Version 0.0302
-
-=cut
-
-our $VERSION = '0.0303';
 
 =head1 SYNOPSIS
 

--- a/t/01-store.t
+++ b/t/01-store.t
@@ -10,8 +10,6 @@ use Catmandu::Store::MongoDB;
 
 use MongoDBTest '$conn';
 
-plan tests => 10;
-
 ok $conn;
 
 my $db = $conn->get_database('test_database');
@@ -47,7 +45,9 @@ $store->bag->delete_all;
 is $store->bag->count , 0;
 
 END {
-	if ($db) {
-		$db->drop;
-	}
+    if ($db) {
+        $db->drop;
+    }
 }
+
+done_testing;

--- a/t/02-connect.t
+++ b/t/02-connect.t
@@ -14,17 +14,14 @@ my @pkgs = qw(
 require_ok $_ for @pkgs;
 
 # Connect to a non-existing host
-my $store = Catmandu->store('MongoDB' , database_name => 'test' , host => 'mongodb://localhost:0');
-
-dies_ok { $store->first } 'expecting to die';
-
-$store = Catmandu->store('MongoDB' , 
-			database_name => 'test' , 
-			host => 'mongodb://localhost:0' , 
-			connect_retry => 2 ,
-			connect_retry_sleep => 2
+my $store = Catmandu->store(
+    'MongoDB',
+    database_name => 'test',
+    host          => 'mongodb://localhost:0'
 );
 
-throws_ok { $store->first } 'Catmandu::Error' , 'expecting to throw a Catmandu::Error';
+dies_ok { $store->first } 'expecting to die';
+throws_ok { $store->first } 'MongoDB::SelectionError',
+    'expecting to throw a MongoDB::SelectionError';
 
-done_testing 5;
+done_testing;

--- a/t/03-deprecated.t
+++ b/t/03-deprecated.t
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Warn;
+
+use Catmandu::Store::MongoDB;
+
+warnings_like {
+    Catmandu::Store::MongoDB->new(
+        database_name       => 'test',
+        host                => 'mongodb://localhost:0',
+        connect_retry       => 2,
+        connect_retry_sleep => 2
+    );
+}
+qr/are deprecated/i, 'warning for deprecated connection parameters';
+
+done_testing;


### PR DESCRIPTION
see #6 
requires MongoDB v1.0.0
deprecated additional connection parameters because of new 'lazy connections' of MongoDB